### PR TITLE
Fix `ValueError` in `launch_kernel()`

### DIFF
--- a/jupyter_existing_provisioner/existing.py
+++ b/jupyter_existing_provisioner/existing.py
@@ -29,8 +29,10 @@ class ExistingProvisioner(KernelProvisionerBase):
 
         _log.info(f'Existing IPython kernel = {connection_file}')
         with open(connection_file) as f:
-            return json.load(f)
-
+            # jupyter_client expects the value of "key" to be bytes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+            file_info = json.load(f)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+            file_info["key"] = file_info["key"].encode()                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
+            return file_info
     async def pre_launch(self, **kwargs):
         kwargs = await super().pre_launch(**kwargs)
         kwargs.setdefault('cmd', None)


### PR DESCRIPTION
Fixes #1.

The exception with message is

```
ValueError: KernelManager's connection information already exists and does not match the expected values returned from provisioner!
```

The exception is raised in `ConnectionFileMixin._reconcile_connection_info()` at `.../site-packages/jupyter_client/connect.py` line 610. The cause is a type mismatch in the `key` value of the JSON-decoded connection file. `jupyter_client` expects the value to be of type `bytes`, but `jupyter_existing_provisioner` sets the value as a `string` . The change in `jupyter_client` leading to this error was [committed](https://github.com/jupyter/jupyter_client/commit/107ccdd06c9b67fc081204ae7c0e7123a17cb0c4) in mid-November, 2022.